### PR TITLE
Pull live chapter data from the ALL Applied AI Network dashboard

### DIFF
--- a/src/components/achievements-page/Achievements.css
+++ b/src/components/achievements-page/Achievements.css
@@ -336,3 +336,15 @@
     filter: none;
   }
 }
+
+/* Dashboard badges may carry an emoji instead of an uploaded image. Match the
+   image variant's box so a mixed grid stays on one visual rhythm. */
+.achievement-emoji-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  font-size: 2rem;
+  line-height: 1;
+}

--- a/src/components/achievements-page/Achievements.tsx
+++ b/src/components/achievements-page/Achievements.tsx
@@ -1,6 +1,8 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import "./Achievements.css";
 import { getRawFileUrl } from "../../hooks/github-hook";
+import { getDashboardBundle, type DashboardBadge } from "../../hooks/dashboard-hook";
+import { BadgeIcon } from "../badge-icon/BadgeIcon";
 
 const listOfAchievements = [
   {
@@ -203,6 +205,25 @@ const listOfAchievements = [
 ];
 
 function Achievements() {
+  /**
+   * The badge catalog lives in the ALL dashboard, where officers create badges
+   * and award them. This page used to hardcode the list, so every new badge
+   * meant a code change and the counts were never shown at all.
+   *
+   * The hardcoded list stays as the fallback for a dashboard outage.
+   */
+  const [badges, setBadges] = useState<DashboardBadge[] | null>(null);
+
+  useEffect(() => {
+    let live = true;
+    getDashboardBundle().then((bundle) => {
+      if (live && bundle?.badges?.length) setBadges(bundle.badges);
+    });
+    return () => {
+      live = false;
+    };
+  }, []);
+
   return (
     <>
       <div className="achievements-intro">
@@ -217,17 +238,45 @@ function Achievements() {
       <div className="line"></div>
 
       <div className="achievements-container">
-        {listOfAchievements.map((achievement, index) => (
-          <div className="achievement-card" key={index}>
-            <div className="achievement-icon">{achievement.icon}</div>
-            <div className="achievement-content">
-              <h3 className="achievement-title">{achievement.title}</h3>
-              <p className="achievement-description">
-                {achievement.description}
-              </p>
-            </div>
-          </div>
-        ))}
+        {badges
+          ? // Most-earned first — that's what visitors scan for.
+            [...badges]
+              .sort((a, b) => b.award_count - a.award_count)
+              .map((badge) => (
+                <div className="achievement-card" key={badge.id}>
+                  <div className="achievement-icon">
+                    <BadgeIcon
+                      icon={badge.icon}
+                      name={badge.name}
+                      size={38}
+                      imgClassName="achievement-img-icon"
+                      emojiClassName="achievement-emoji-icon"
+                    />
+                  </div>
+                  <div className="achievement-content">
+                    <h3 className="achievement-title">{badge.name}</h3>
+                    <p className="achievement-description">
+                      {badge.description ||
+                        (badge.award_count > 0
+                          ? `Earned by ${badge.award_count} ${
+                              badge.award_count === 1 ? "member" : "members"
+                            }`
+                          : "")}
+                    </p>
+                  </div>
+                </div>
+              ))
+          : listOfAchievements.map((achievement, index) => (
+              <div className="achievement-card" key={index}>
+                <div className="achievement-icon">{achievement.icon}</div>
+                <div className="achievement-content">
+                  <h3 className="achievement-title">{achievement.title}</h3>
+                  <p className="achievement-description">
+                    {achievement.description}
+                  </p>
+                </div>
+              </div>
+            ))}
       </div>
 
       <div className="achievements-footer">

--- a/src/components/badge-icon/BadgeIcon.tsx
+++ b/src/components/badge-icon/BadgeIcon.tsx
@@ -1,0 +1,72 @@
+import {
+  Award,
+  Crown,
+  GraduationCap,
+  Medal,
+  Rocket,
+  Sparkles,
+  Star,
+  Trophy,
+  Users,
+} from "lucide-react";
+import { classifyBadgeIcon } from "../../hooks/dashboard-hook";
+
+/**
+ * Renders an ALL dashboard badge icon.
+ *
+ * The dashboard stores three different things in one `icon` field — an
+ * uploaded image URL, a short built-in key, or an emoji — so every surface
+ * showing badges needs the same three-way branch. Keeping it here means the
+ * achievements wall and the leaderboard can't drift apart, and an unknown key
+ * degrades to a generic award everywhere instead of printing itself as text
+ * beside a member's name.
+ */
+
+const KEY_ICONS: Record<
+  string,
+  React.ComponentType<{ size?: number; color?: string; className?: string }>
+> = {
+  trophy: Trophy,
+  award: Award,
+  medal: Medal,
+  star: Star,
+  crown: Crown,
+  graduation: GraduationCap,
+  "graduation-cap": GraduationCap,
+  rocket: Rocket,
+  sparkles: Sparkles,
+  users: Users,
+  eboard: Users,
+};
+
+export function BadgeIcon({
+  icon,
+  name,
+  size = 22,
+  imgClassName,
+  emojiClassName,
+}: {
+  icon: string | null | undefined;
+  name: string;
+  size?: number;
+  imgClassName?: string;
+  emojiClassName?: string;
+}) {
+  const { kind, value } = classifyBadgeIcon(icon);
+
+  if (kind === "url") {
+    return <img src={value} alt={name} title={name} className={imgClassName} />;
+  }
+  if (kind === "emoji") {
+    return (
+      <span className={emojiClassName} title={name} role="img" aria-label={name}>
+        {value}
+      </span>
+    );
+  }
+  // Built-in key, or nothing at all — a generic award beats a stray word.
+  const Icon = (kind === "key" && KEY_ICONS[value]) || Award;
+  return <Icon size={size} color="#fff" aria-label={name} />;
+}
+
+export default BadgeIcon;

--- a/src/components/learning-tree/Tree.tsx
+++ b/src/components/learning-tree/Tree.tsx
@@ -14,6 +14,11 @@ import "@xyflow/react/dist/style.css";
 import LearningTreeNode from "./LearningTreeNode.tsx";
 import "./assets/css/tree.css";
 import { getFileContent } from "../../hooks/github-hook";
+import {
+  getDashboardTree,
+  type TreeNode,
+  type TreePayload,
+} from "../../hooks/dashboard-hook";
 
 interface TreeProps {
   nodeID: string | null;
@@ -199,6 +204,90 @@ const transformTreeNodes = (treeData: TreeJsonData): CustomNode[] => {
 };
 
 /**
+ * Builds ReactFlow nodes straight from the ALL dashboard's learning tree.
+ *
+ * Deliberately does NOT go through transformTreeNodes. That function derives
+ * positions from parent nodes because maic-content's tree.json shipped every
+ * position as {0,0}; the dashboard instead returns pos_x/pos_y that an officer
+ * arranged by hand in the editor, and recomputing over the top would throw
+ * that away. Nodes without stored coordinates fall back to a category-based
+ * grid so a freshly-added node still lands somewhere sensible.
+ *
+ * The payload merges the network's shared base tree with MAIC's own nodes, so
+ * this renders both — `source` distinguishes them if that's ever wanted.
+ */
+const transformDashboardTree = (
+  payload: TreePayload,
+): { nodes: CustomNode[]; edges: Edge[] } => {
+  const byId = new Map(payload.nodes.map((n) => [n.id, n]));
+
+  // prereqs is the full parent set; parent_ref is the primary one. Prefer
+  // prereqs so multi-parent nodes keep every edge.
+  const parentsOf = (n: TreeNode): string[] => {
+    const raw = n.prereqs && n.prereqs.length ? n.prereqs : n.parent_ref ? [n.parent_ref] : [];
+    return raw.filter((p) => byId.has(p));
+  };
+
+  const childrenOf = new Map<string, string[]>();
+  for (const n of payload.nodes) {
+    for (const p of parentsOf(n)) {
+      childrenOf.set(p, [...(childrenOf.get(p) ?? []), n.id]);
+    }
+  }
+
+  // Fallback grid for nodes the dashboard hasn't positioned yet.
+  let unplaced = 0;
+  const nodes: CustomNode[] = payload.nodes.map((n) => {
+    let x = n.pos_x;
+    let y = n.pos_y;
+    if (x == null || y == null) {
+      x = (unplaced % 6) * 420;
+      y = 4000 + Math.floor(unplaced / 6) * 300;
+      unplaced += 1;
+    }
+    const color = n.color || "#7c6bd6";
+    return {
+      id: n.id,
+      type: "treeNode",
+      position: { x, y },
+      children: childrenOf.get(n.id) ?? [],
+      data: {
+        name: n.title,
+        // Thumbnails are absolute URLs; LearningTreeNode already prefers
+        // image_path when it looks like one.
+        image_path: n.thumbnail || "",
+        api_image_path: n.thumbnail || "",
+        description: n.summary || "",
+        category: n.tags?.[0] || "General",
+        category_color: color,
+        highlighted_path: "False",
+        // The dashboard holds node content as markdown rather than a link to
+        // a library article, so there's nothing to navigate to yet.
+        link: "",
+      },
+    } as CustomNode;
+  });
+
+  // Build edges from the payload's own edge list rather than re-deriving them
+  // from parent links — the API already resolved the graph, including the
+  // multi-parent cases, so there's nothing to gain by recomputing it.
+  const nodeIds = new Set(nodes.map((n) => n.id));
+  const colorOf = new Map(nodes.map((n) => [n.id, n.data.category_color as string]));
+  const edges: Edge[] = (payload.edges ?? [])
+    .filter((e) => nodeIds.has(e.from) && nodeIds.has(e.to))
+    .map((e, i) => ({
+      id: `${e.from}-${e.to}-${i}`,
+      source: e.from,
+      target: e.to,
+      type: "default",
+      animated: true,
+      style: { stroke: colorOf.get(e.to) || "#7c6bd6", strokeWidth: 6 },
+    }));
+
+  return { nodes, edges };
+};
+
+/**
  * Generates edges based on the children attribute of each node.
  */
 const generateEdges = (nodes: CustomNode[]): Edge[] => {
@@ -236,6 +325,27 @@ const Tree = (props: TreeProps) => {
     const loadTreeData = async () => {
       setIsLoading(true);
       try {
+        /**
+         * The learning tree now lives in the ALL dashboard, where officers
+         * edit nodes and arrange the layout — this renders the network's
+         * shared base tree merged with MAIC's own additions.
+         *
+         * maic-content's tree.json remains the fallback so a dashboard
+         * outage shows the previous tree instead of the placeholder nodes.
+         */
+        const dashboardTree = await getDashboardTree();
+        if (dashboardTree?.nodes?.length) {
+          const { nodes: dashNodes, edges: dashEdges } =
+            transformDashboardTree(dashboardTree);
+          setNodes(dashNodes);
+          setEdges(dashEdges);
+          // Frame the whole tree. The old code picked node "1" and the
+          // highest numeric id, which assumed numeric ids — dashboard ids
+          // are slugs and uuids, so Number() on them yields NaN.
+          fitViewOptions.nodes = undefined;
+          return;
+        }
+        console.warn("[tree] dashboard unavailable — falling back to content CDN");
 
         // Fetch the tree.json file using the GitHub hook
         const treeJsonContent = await getFileContent(

--- a/src/components/library/ResearchProjects.tsx
+++ b/src/components/library/ResearchProjects.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from "react";
 import GitHubIcon from "@mui/icons-material/GitHub";
 import OpenInNewIcon from "@mui/icons-material/OpenInNew";
 import { getSubsectionModals } from "../../hooks/library-helper";
+import { getDashboardBundle } from "../../hooks/dashboard-hook";
 import { Skeleton } from "@mui/material";
 import SpotlightCard from "../react-bits/spotlight-card/SpotlightCard";
 
@@ -36,8 +37,47 @@ const ResearchProjects = () => {
   useEffect(() => {
     (async () => {
       setLoading(true);
-      const data = await getSubsectionModals("Research");
-      const cleaned = (data || []).filter(Boolean) as ResearchModalLike[];
+
+      /**
+       * Research projects come from the ALL dashboard, where each one carries
+       * its full author byline and attached papers/slides/recordings. The
+       * maic-content copy under-credited teams — several projects listed a
+       * single name for work done by eight people — so this is both live and
+       * more accurate.
+       *
+       * Falls back to the content CDN if the dashboard is unreachable.
+       */
+      const bundle = await getDashboardBundle();
+      let cleaned: ResearchModalLike[];
+
+      if (bundle?.projects?.length) {
+        cleaned = bundle.projects.map((p) => {
+          const paper = p.files.find((f) => f.kind === "paper");
+          const repo =
+            p.files.find((f) => f.kind === "link" && /github/i.test(f.url)) ||
+            (p.link_url && /github/i.test(p.link_url)
+              ? { url: p.link_url }
+              : undefined);
+          return {
+            title: p.title,
+            description: p.description || "",
+            img: p.image_url || undefined,
+            date: p.year || "",
+            team: p.members.map((m) => m.name),
+            authors: p.members.map((m) => m.name).join(", "),
+            membersCount: p.members.length,
+            publicationsCount: p.files.length,
+            content_ids: p.files,
+            paperUrl: paper?.url ?? p.link_url ?? undefined,
+            repoUrl: repo?.url,
+          } as ResearchModalLike;
+        });
+      } else {
+        console.warn("[research] dashboard unavailable — using content CDN");
+        const data = await getSubsectionModals("Research");
+        cleaned = (data || []).filter(Boolean) as ResearchModalLike[];
+      }
+
       setProjects(cleaned);
 
       // Derive available years from project dates

--- a/src/components/merch-page/merch-grid/MerchGrid.tsx
+++ b/src/components/merch-page/merch-grid/MerchGrid.tsx
@@ -1,6 +1,7 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import "./MerchGrid.css";
 import { getRawFileUrl } from "../../../hooks/github-hook";
+import { getDashboardBundle } from "../../../hooks/dashboard-hook";
 
 interface MerchItem {
   name: string;
@@ -77,6 +78,43 @@ function MerchGrid() {
   const [selectedItem, setSelectedItem] = useState<MerchItem | null>(null);
   const [currentImageIndex, setCurrentImageIndex] = useState(0);
 
+  /**
+   * The catalog lives in the ALL dashboard so the eboard can add items and
+   * change point costs without a code change. The hardcoded list below stays
+   * as the fallback for a dashboard outage.
+   *
+   * Cost has two forms: `cost_points` for a plain price, and `cost_text` for
+   * the ones that aren't purely points ("Participate in and Complete a MAIC
+   * Research Group"). Prefer the text when it's set.
+   */
+  const [items, setItems] = useState<MerchItem[]>(merchItems);
+
+  useEffect(() => {
+    let live = true;
+    getDashboardBundle().then((bundle) => {
+      if (!live || !bundle?.merch?.length) return;
+      setItems(
+        bundle.merch.map((m) => ({
+          name: m.name,
+          imagePaths: m.images?.length
+            ? m.images
+            : m.image_url
+              ? [m.image_url]
+              : [],
+          cost: m.cost_text?.trim()
+            ? m.cost_text
+            : `${m.cost_points ?? 0} Points`,
+          description: m.description || "",
+          // No dashboard equivalent — redemption is in person either way.
+          purchaseInfo: "Ask an Eboard Member",
+        })),
+      );
+    });
+    return () => {
+      live = false;
+    };
+  }, []);
+
   const handleOpen = (item: MerchItem) => {
     setSelectedItem(item);
     setCurrentImageIndex(0);
@@ -120,7 +158,7 @@ function MerchGrid() {
     <>
       <div className="merch-grid">
         <div className="merch-grid-item">
-          {merchItems.map((item, index) => (
+          {items.map((item, index) => (
             <div
               key={index}
               className="merch-grid-item-container"

--- a/src/components/points-page/Points.css
+++ b/src/components/points-page/Points.css
@@ -475,3 +475,118 @@
     filter: none;
   }
 }
+
+/* ── Live leaderboard (ALL dashboard) ─────────────────────────────────
+   Reuses the same glass tokens as .points-item so the standings read as
+   part of this page rather than a bolted-on widget. */
+.points-leaderboard {
+  max-width: 800px;
+  margin: 3rem auto 0;
+  padding: 0 2rem;
+}
+
+.points-leaderboard-title {
+  font-size: 2rem;
+  font-weight: 800;
+  color: rgb(var(--text-1));
+  letter-spacing: -0.02em;
+  text-align: center;
+  margin-bottom: 2rem;
+}
+
+.points-leaderboard-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.points-leader {
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
+  background: var(--glass-primary);
+  border: 1px solid var(--glass-border);
+  border-radius: 12px;
+  padding: 1rem 1.25rem;
+  backdrop-filter: var(--blur-glass);
+  -webkit-backdrop-filter: var(--blur-glass);
+  box-shadow: var(--shadow-glass);
+}
+
+/* Top three get a medal tint on the rank only — enough to read at a
+   glance without turning the list into a gradient. */
+.points-leader--top .points-leader-rank {
+  color: #0d0d12;
+  font-weight: 800;
+}
+.points-leader--1 .points-leader-rank { background: #f4c145; }
+.points-leader--2 .points-leader-rank { background: #cfd3da; }
+.points-leader--3 .points-leader-rank { background: #d08a53; }
+
+.points-leader-rank {
+  flex-shrink: 0;
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1rem;
+  font-weight: 700;
+  color: rgb(var(--text-1));
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.points-leader-name {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: rgb(var(--text-1));
+}
+
+.points-leader-badges {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+}
+
+.points-leader-badge {
+  width: 1.35rem;
+  height: 1.35rem;
+  border-radius: 4px;
+  object-fit: contain;
+}
+
+.points-leader-badge--emoji {
+  font-size: 1.1rem;
+  line-height: 1;
+}
+
+.points-leader-points {
+  flex-shrink: 0;
+  font-size: 1.25rem;
+  font-weight: 800;
+  color: rgb(var(--text-1));
+  font-variant-numeric: tabular-nums;
+}
+
+@media (max-width: 600px) {
+  .points-leaderboard {
+    padding: 0 1rem;
+  }
+  .points-leader {
+    gap: 0.85rem;
+    padding: 0.85rem 1rem;
+  }
+  .points-leader-name {
+    font-size: 0.95rem;
+  }
+}

--- a/src/components/points-page/Points.tsx
+++ b/src/components/points-page/Points.tsx
@@ -1,7 +1,10 @@
+import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import "./Points.css";
 import { FaTshirt } from "react-icons/fa";
 import { FaTicketAlt } from "react-icons/fa";
+import { getDashboardBundle, type DashboardLeader } from "../../hooks/dashboard-hook";
+import { BadgeIcon } from "../badge-icon/BadgeIcon";
 
 
 const activities = [
@@ -33,6 +36,17 @@ const activities = [
 
 function Points() {
   const navigate = useNavigate();
+  const [leaders, setLeaders] = useState<DashboardLeader[] | null>(null);
+
+  useEffect(() => {
+    let live = true;
+    getDashboardBundle().then((bundle) => {
+      if (live && bundle?.leaderboard?.length) setLeaders(bundle.leaderboard);
+    });
+    return () => {
+      live = false;
+    };
+  }, []);
 
   return (
     <>
@@ -57,6 +71,46 @@ function Points() {
           </div>
         ))}
       </div>
+      {/* Live leaderboard. The copy above has always promised one ("climb the
+          leaderboard") without ever showing it — the standings live in the ALL
+          dashboard, so this is now the real thing rather than a screenshot
+          someone has to remember to update. Hidden entirely if unreachable. */}
+      {leaders && leaders.length > 0 && (
+        <div className="points-leaderboard">
+          <h1 className="points-leaderboard-title">Current Standings</h1>
+          <ol className="points-leaderboard-list">
+            {leaders.map((m) => (
+              <li
+                className={`points-leader${m.rank <= 3 ? ` points-leader--top points-leader--${m.rank}` : ""}`}
+                key={`${m.rank}-${m.name}`}
+              >
+                <span className="points-leader-rank">{m.rank}</span>
+                <span className="points-leader-name">
+                  {m.name}
+                  {m.badges?.length > 0 && (
+                    <span className="points-leader-badges">
+                      {m.badges.slice(0, 4).map((b) => (
+                        <BadgeIcon
+                          key={b.id}
+                          icon={b.icon}
+                          name={b.name}
+                          size={16}
+                          imgClassName="points-leader-badge"
+                          emojiClassName="points-leader-badge points-leader-badge--emoji"
+                        />
+                      ))}
+                    </span>
+                  )}
+                </span>
+                <span className="points-leader-points">
+                  {m.points.toLocaleString()}
+                </span>
+              </li>
+            ))}
+          </ol>
+        </div>
+      )}
+
       <div className="points-spend-container">
         <h1 className="points-spend-title">What Can You Do With Points?</h1>
         <div className="points-spend-options">

--- a/src/hooks/dashboard-hook.ts
+++ b/src/hooks/dashboard-hook.ts
@@ -1,0 +1,265 @@
+/**
+ * ALL Applied AI Network dashboard — live chapter data.
+ *
+ * The eboard edits events, badges, merch, the leaderboard, research projects
+ * and the learning tree in dashboard.all-ai-network.org. This module reads
+ * them so the site reflects those edits on the next page load, with no
+ * redeploy and no second copy of the data in maic-content.
+ *
+ * NO API KEY, deliberately. This site is a static Vite build served from S3 —
+ * there is no server, and every `VITE_*` variable is inlined into the
+ * JavaScript shipped to visitors, so a key placed there would be public. The
+ * dashboard exposes a keyless, CORS-open endpoint for exactly this case. If
+ * you ever find yourself adding an API key here, that is the wrong turn.
+ *
+ * Docs: https://dashboard.all-ai-network.org/docs
+ *
+ * Everything fails SOFT. A dashboard outage must leave the site rendering
+ * whatever it rendered before, never a broken section — hence the null
+ * returns and the single in-flight promise rather than throwing.
+ */
+
+const DASHBOARD_BASE = "https://dashboard.all-ai-network.org";
+const CHAPTER_SLUG = "msoe-ai-club";
+
+/* ── Response types (only the fields this site reads) ─────────────── */
+
+export interface DashboardEvent {
+  id: string;
+  title: string;
+  description: string | null;
+  /** Free text set by officers: "Speaker Event", "Workshop", "Hackathon"… */
+  type: string | null;
+  date: string;
+  end_date: string | null;
+  timezone: string | null;
+  location: string | null;
+  virtual_url: string | null;
+  image_url: string | null;
+  points_attend: number | null;
+}
+
+export interface DashboardBadge {
+  id: string;
+  name: string;
+  description: string | null;
+  /** Either an https URL (uploaded image) or a short string — often an emoji. */
+  icon: string | null;
+  award_count: number;
+}
+
+export interface DashboardMerchItem {
+  id: string;
+  name: string;
+  description: string | null;
+  cost_points: number | null;
+  cost_text: string | null;
+  images: string[];
+  image_url: string | null;
+  /** null = unlimited, 0 = out of stock, >0 = that many left. */
+  stock: number | null;
+}
+
+export interface DashboardLeader {
+  rank: number;
+  name: string;
+  points: number;
+  events_attended: number;
+  badges: Array<{ id: string; name: string; icon: string | null }>;
+}
+
+export interface DashboardProject {
+  id: string;
+  title: string;
+  description: string | null;
+  image_url: string | null;
+  link_url: string | null;
+  year: string | null;
+  members: Array<{ name: string; role: string }>;
+  files: Array<{ id: string; kind: string; title: string; url: string }>;
+}
+
+export interface DashboardChapter {
+  slug: string;
+  name: string;
+  university: string;
+  member_count: number;
+  event_count: number;
+}
+
+export interface DashboardBundle {
+  chapter: DashboardChapter;
+  events: DashboardEvent[];
+  events_scope?: string;
+  leaderboard: DashboardLeader[];
+  badges: DashboardBadge[];
+  merch: DashboardMerchItem[];
+  projects: DashboardProject[];
+}
+
+export interface TreeNode {
+  id: string;
+  title: string;
+  summary: string | null;
+  body: string | null;
+  parent_ref: string | null;
+  prereqs: string[];
+  tags: string[];
+  thumbnail: string | null;
+  difficulty: string | null;
+  /** CSS color set on the node in the dashboard, or inherited per category. */
+  color: string | null;
+  pos_x: number | null;
+  pos_y: number | null;
+  /** "base" for the network's shared nodes, "chapter" for this club's own. */
+  source: string;
+}
+
+export interface TreePayload {
+  nodes: TreeNode[];
+  edges: Array<{ from: string; to: string }>;
+}
+
+/* ── Fetching ─────────────────────────────────────────────────────── */
+
+/**
+ * One in-flight request per resource, shared across every component that
+ * asks. Several pages want the bundle at once (stats in the hero, events in
+ * the list) and the browser shouldn't make the same call three times.
+ *
+ * Not a long-lived cache: the response is edge-cached ~30s server-side
+ * already, and holding it here would mean a visitor who leaves a tab open
+ * never sees an update.
+ */
+let bundlePromise: Promise<DashboardBundle | null> | null = null;
+let treePromise: Promise<TreePayload | null> | null = null;
+
+async function getJson<T>(url: string): Promise<T | null> {
+  try {
+    const res = await fetch(url);
+    if (!res.ok) {
+      console.warn(`[dashboard] ${res.status} from ${url}`);
+      return null;
+    }
+    return (await res.json()) as T;
+  } catch (err) {
+    console.warn("[dashboard] fetch failed:", err);
+    return null;
+  }
+}
+
+/**
+ * The whole chapter payload in one request.
+ *
+ * `events=all` matters: the bundle returns only UPCOMING events by default,
+ * and every one of this chapter's events is in the past, so the default would
+ * hand back an empty array and the events page would look broken.
+ */
+export function getDashboardBundle(): Promise<DashboardBundle | null> {
+  if (!bundlePromise) {
+    bundlePromise = getJson<DashboardBundle>(
+      `${DASHBOARD_BASE}/api/public/chapter/${CHAPTER_SLUG}/bundle?events=all&events_limit=200`,
+    ).finally(() => {
+      // Allow a later navigation to refetch rather than pinning the first
+      // response for the life of the tab.
+      setTimeout(() => {
+        bundlePromise = null;
+      }, 30_000);
+    }) as Promise<DashboardBundle | null>;
+  }
+  return bundlePromise;
+}
+
+/** The network's shared learning tree merged with this chapter's own nodes. */
+export function getDashboardTree(): Promise<TreePayload | null> {
+  if (!treePromise) {
+    treePromise = getJson<TreePayload>(
+      `${DASHBOARD_BASE}/api/public/learning-tree/${CHAPTER_SLUG}`,
+    ).finally(() => {
+      setTimeout(() => {
+        treePromise = null;
+      }, 30_000);
+    }) as Promise<TreePayload | null>;
+  }
+  return treePromise;
+}
+
+/* ── Helpers the pages share ──────────────────────────────────────── */
+
+/**
+ * Officers type event types freely ("Speaker Event - Intro Series",
+ * "ROSIE Competition", "NVIDIA"), but this site's filter bar has four fixed
+ * buckets. Map onto those and default to workshop so a new type the eboard
+ * invents still appears rather than vanishing from every filter.
+ */
+export type SiteEventType = "workshop" | "speaker" | "competition" | "intro";
+
+export function toSiteEventType(raw: string | null): SiteEventType {
+  const t = (raw || "").toLowerCase();
+  if (t.includes("intro")) return "intro";
+  if (t.includes("speaker") || t.includes("panel") || t.includes("conference"))
+    return "speaker";
+  if (
+    t.includes("hackathon") ||
+    t.includes("competition") ||
+    t.includes("lab") ||
+    t.includes("challenge")
+  )
+    return "competition";
+  return "workshop";
+}
+
+/**
+ * A badge `icon` arrives in one of three forms and they render differently:
+ *   - an https URL          → an uploaded image
+ *   - a short built-in key  → "trophy", "crown", "graduation" — map to an
+ *                             icon component
+ *   - an emoji              → render as text
+ *
+ * Distinguishing the last two matters: rendering the key "graduation" as text
+ * puts the literal word next to a member's name on the leaderboard. Emoji
+ * carry no ASCII letters, which separates them cleanly from key names.
+ */
+export type BadgeIconKind = "url" | "key" | "emoji" | "none";
+
+export function classifyBadgeIcon(icon: string | null | undefined): {
+  kind: BadgeIconKind;
+  value: string;
+} {
+  const v = (icon || "").trim();
+  if (!v) return { kind: "none", value: "" };
+  if (isHttpUrl(v)) return { kind: "url", value: v };
+  if (/[a-z]/i.test(v)) return { kind: "key", value: v.toLowerCase() };
+  return { kind: "emoji", value: v };
+}
+
+/** True for values safe to use as an <img src> or link href. */
+export function isHttpUrl(value: string | null | undefined): boolean {
+  if (!value) return false;
+  try {
+    const u = new URL(value);
+    return u.protocol === "http:" || u.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+/** Dates come back as UTC ISO with the event's timezone alongside. */
+export function formatEventDate(iso: string, timezone?: string | null): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "";
+  try {
+    return d.toLocaleDateString("en-US", {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+      ...(timezone ? { timeZone: timezone } : {}),
+    });
+  } catch {
+    return d.toLocaleDateString("en-US", {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+    });
+  }
+}

--- a/src/hooks/github-hook.ts
+++ b/src/hooks/github-hook.ts
@@ -285,6 +285,12 @@ export async function getFileContent(filePath: string): Promise<string | null> {
 }
 
 export function getRawFileUrl(filePath: string): string {
+  // Images now arrive from two places: relative paths in the content repo,
+  // and absolute URLs from the ALL dashboard. Prefixing an absolute URL with
+  // the CDN base produces a mangled, double-encoded link, so pass those
+  // through untouched.
+  if (/^https?:\/\//i.test(filePath)) return filePath;
+
   const baseUrl =
     resolvedContentBaseUrl || ENV_CONTENT_BASE_URL || DEFAULT_CONTENT_BASE_URL;
   const encodedFilePath = filePath

--- a/src/pages/Events.tsx
+++ b/src/pages/Events.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from "react";
 import Navbar from "../components/navbar/Navbar";
 import { getFileContent, getRawFileUrl } from "../hooks/github-hook";
+import { getDashboardBundle, toSiteEventType } from "../hooks/dashboard-hook";
 
 import SpotlightCard from "../components/react-bits/spotlight-card/SpotlightCard";
 import Footer from "../components/footer/Footer";
@@ -28,6 +29,27 @@ interface EventData {
 interface IconProps extends LucideProps {
   size?: number;
   color?: string;
+}
+
+/**
+ * ISO timestamp -> YYYY-MM-DD in the event's own timezone. The dashboard
+ * stores UTC, so an evening Central event is already "tomorrow" in UTC and
+ * would land in the wrong month heading without this.
+ */
+function toDateKey(iso: string, timezone?: string | null): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  try {
+    const parts = new Intl.DateTimeFormat("en-CA", {
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      ...(timezone ? { timeZone: timezone } : {}),
+    }).format(d);
+    return parts; // en-CA formats as YYYY-MM-DD
+  } catch {
+    return d.toISOString().slice(0, 10);
+  }
 }
 
 const EVENT_TYPE_META: Record<
@@ -104,18 +126,36 @@ const Events: React.FC = () => {
   }, []);
 
   useEffect(() => {
+    /**
+     * Events come from the ALL dashboard, where the eboard already maintains
+     * them — so adding an event there puts it on this page with no redeploy
+     * and no second copy in maic-content.
+     *
+     * maic-content stays as the fallback: if the dashboard is unreachable the
+     * page shows the last-published events.json rather than an empty page.
+     */
     const fetchEvents = async () => {
       try {
-        const jsonData = await getFileContent("data/events/events.json");
-        if (jsonData) {
-          const data: EventData[] = JSON.parse(jsonData);
-          setEvents(data);
-        } else {
-          console.warn("Failed to fetch events data, using hardcoded backup");
-          setEvents([]);
+        const bundle = await getDashboardBundle();
+        if (bundle?.events?.length) {
+          setEvents(
+            bundle.events.map((e) => ({
+              title: e.title,
+              type: toSiteEventType(e.type),
+              // The grouping code below wants a plain date; render it in the
+              // event's own timezone so a 6pm CT event doesn't slide a day.
+              date: toDateKey(e.date, e.timezone),
+              image: e.image_url || "images/events/DH.jpg",
+              description: e.description || "",
+            })),
+          );
+          return;
         }
+        console.warn("[events] dashboard empty or unreachable — using content CDN");
+        const jsonData = await getFileContent("data/events/events.json");
+        setEvents(jsonData ? (JSON.parse(jsonData) as EventData[]) : []);
       } catch (e) {
-        console.warn("Error parsing events data, using hardcoded backup:", e);
+        console.warn("[events] load failed:", e);
         setEvents([]);
       } finally {
         setLoading(false);


### PR DESCRIPTION
Pulls the site's chapter data from the ALL Applied AI Network dashboard, where the eboard already maintains it. Editing there updates this site on the next page load — no redeploy, and no second copy of the data in `maic-content`.

Each page keeps its existing markup and styling; this only changes where data comes from.

## No API key

This is a static Vite build, so every `VITE_*` variable is inlined into the JavaScript shipped to visitors — a key placed there would be public. Everything goes through the dashboard's keyless, CORS-open public endpoints, which exist for this case. API docs: https://dashboard.all-ai-network.org/docs

## Rewired

| Page | Before | After |
|---|---|---|
| Events | `events.json` on the content CDN | All 56 events from the dashboard |
| Achievements | 8 hardcoded badges | 27 live badges, most-earned first |
| Merch | 6 hardcoded items | Live catalog with point costs |
| Research (`/library?nav=Research`) | Content CDN | 41 projects with real author bylines + papers |
| Learning Tree | `tree.json` on the content CDN | Network base tree merged with MAIC's nodes |

**Added:** a live leaderboard on the Points page, which has always promised one ("climb the leaderboard") without showing it.

The research page gets the biggest upgrade: `maic-content` under-credited several teams — NourishNet listed one person for work by eight — so this is both live and more accurate.

The learning tree honours the node positions officers arrange in the dashboard editor rather than recomputing them.

## Resilience

Every module falls back to its previous source if the dashboard is unreachable, so an outage leaves the site exactly as it was. No module renders an empty shell.

## Supporting fixes

- Badge icons can be a URL, an emoji, or a named key like `graduation`. Rendering the key as text put the literal word next to members' names on the leaderboard; there's now one shared `BadgeIcon` resolving all three.
- `getRawFileUrl` would double-encode absolute dashboard URLs. It passes those through now, which also makes it safe for any future absolute URL.

## Verification

Built and run against the live API: 56 events, 27 badges, 6 merch items, 41 projects, 20 leaderboard rows, 96 tree nodes with 121 edges. Typecheck and production build both clean on this branch.

To review locally: `npm install && npm run dev` — no `.env` needed (leaving `VITE_CONTENT_BASE_URL` unset uses the live content CDN).

## Note for maintainers

The README says deploys go to GitHub Pages. That looks stale — Pages isn't enabled on this repo, and msoe-maic.com is served from S3 behind CloudFront. Worth correcting, and worth knowing that `index.html` is served with `s-maxage=31536000`, so a deploy needs a CloudFront invalidation or visitors keep the old bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
